### PR TITLE
Require curly braces, prohibit == and !=, prohibit .caller and .callee

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,5 +7,8 @@
 
     // prohibit the use of arguments.caller and arguments.callee
     // both .caller and .callee will be deprecated in future versions of JavaScript
-    "noarg": true
+    "noarg": true,
+
+    // prohibit the use of a variable before it was defined
+    "latedef": true
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,5 @@
+{
+	"curly": true,
+	"eqeqeq": true,
+	"noarg": true
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,11 @@
 {
-	"curly": true,
-	"eqeqeq": true,
-	"noarg": true
+    // require curly braces around blocks in loops and conditionals
+    "curly": true,
+
+    // prohibit use of == and != in favor of === and !==
+    "eqeqeq": true,
+
+    // prohibit the use of arguments.caller and arguments.callee
+    // both .caller and .callee will be deprecated in future versions of JavaScript
+    "noarg": true
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,8 +55,7 @@ module.exports = function(grunt) {
               cwd: 'app/stylesheets',
               src: ['*.css', '!*.min.css'],
               dest: 'dist/css',
-              ext: '.min.css',
-              extDot: 'last' // Extensions in filenames begin after the last dot. http://stackoverflow.com/a/24702850/23566
+              ext: '.min.css'
             }]
           }
         }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,10 @@ module.exports = function(grunt) {
         pkg: grunt.file.readJSON('package.json'),
 
         jshint : {
-            all: ['Gruntfile.js', 'package.json', 'app/javascripts/**/*.js']
+            all: ['Gruntfile.js', 'package.json', 'app/javascripts/**/*.js'],
+            options: {
+                jshintrc: true
+            }
         },
 
         concat : {
@@ -52,7 +55,8 @@ module.exports = function(grunt) {
               cwd: 'app/stylesheets',
               src: ['*.css', '!*.min.css'],
               dest: 'dist/css',
-              ext: '.min.css'
+              ext: '.min.css',
+              extDot: 'last' // Extensions in filenames begin after the last dot. http://stackoverflow.com/a/24702850/23566
             }]
           }
         }

--- a/app/javascripts/components/parent.js
+++ b/app/javascripts/components/parent.js
@@ -23,7 +23,9 @@
             };
 
             this.domloaded = function (ele, isInit, ctx) {
-                if (isInit) return;
+                if (isInit) {
+                    return;
+                }
 
                 menu = document.getElementById('menu');
                 show = document.getElementById('menu-show');


### PR DESCRIPTION
JSHint comes with a default set of warnings but it was designed to be very configurable. This pull request adds `.jshintrc` for our own configuration overrides of JSHint behavior. See http://jshint.com/docs/options/ for details.