### PR TITLE
Make the minifier correctly process CSS filenames with more than one dot.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,7 +52,8 @@ module.exports = function(grunt) {
               cwd: 'app/stylesheets',
               src: ['*.css', '!*.min.css'],
               dest: 'dist/css',
-              ext: '.min.css'
+              ext: '.min.css',
+              extDot: 'last' // Extensions in filenames begin after the last dot. http://stackoverflow.com/a/24702850/23566
             }]
           }
         }


### PR DESCRIPTION
When the filename is like `bootstrap.overrides.css`, cssmin will now generate `bootstrap.overrides.min.css`. I ran into this setting while experimenting with my CSS overrides of the leaflet-fullscreen button.

Right now, this repo does not have any CSS files with more than one filename dot, so this changeset is *not* necessary... Ignore this pull request if you wish; we can probably get by to avoid names having more than one dot -- just use dashes instead, e.g. `bootstrap-overrides.css`